### PR TITLE
Do PNGFiles load check/import sequentially

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@latest
+        env:
+          JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ arch:
 julia:
   - 1
   - nightly
+env:
+  - JULIA_NUM_THREADS=2
 jobs:
   allow_failures:
     - julia: nightly

--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -1,40 +1,43 @@
 module ImageIO
 
-using FileIO: File, DataFormat, Stream, stream
+using FileIO: File, DataFormat, Stream, stream, _findmod, topimport
 
 const load_locker = Base.ReentrantLock()
 
 function checked_import(pkg::Symbol)
     lock(load_locker) do
-        if !isdefined(ImageIO, pkg)
-            @eval ImageIO import $pkg
+        if isdefined(Main, pkg)
+            m1 = getfield(Main, pkg)
+            isa(m1, Module) && return m1
         end
+        if isdefined(ImageIO, pkg)
+            m1 = getfield(ImageIO, pkg)
+            isa(m1, Module) && return m1
+        end
+        m = _findmod(pkg)
+        m == nothing || return Base.loaded_modules[m]
+        topimport(pkg)
+        return Base.loaded_modules[_findmod(pkg)]
     end
-    return nothing
 end
 
 ## PNGs
 
 function load(f::File{DataFormat{:PNG}}; kwargs...)
-    checked_import(:PNGFiles)
-    return Base.invokelatest(PNGFiles.load, f.filename, kwargs...)
+    return Base.invokelatest(checked_import(:PNGFiles).load, f.filename, kwargs...)
 end
 function load(s::Stream{DataFormat{:PNG}}; kwargs...)
-    checked_import(:PNGFiles)
-    return Base.invokelatest(PNGFiles.load, stream(s), kwargs...)
+    return Base.invokelatest(checked_import(:PNGFiles).load, stream(s), kwargs...)
 end
 function load(s::IO; kwargs...)
-    checked_import(:PNGFiles)
-    return Base.invokelatest(PNGFiles.load, s, kwargs...)
+    return Base.invokelatest(checked_import(:PNGFiles).load, s, kwargs...)
 end
 
 function save(f::File{DataFormat{:PNG}}, image::S; kwargs...) where {T, S<:Union{AbstractMatrix, AbstractArray{T,3}}}
-    checked_import(:PNGFiles)
-    return Base.invokelatest(PNGFiles.save, f.filename, image, kwargs...)
+    return Base.invokelatest(checked_import(:PNGFiles).save, f.filename, image, kwargs...)
 end
 function save(s::Stream{DataFormat{:PNG}}, image::S; kwargs...) where {T, S<:Union{AbstractMatrix, AbstractArray{T,3}}}
-    checked_import(:PNGFiles)
-    return Base.invokelatest(PNGFiles.save, stream(s), image, kwargs...)
+    return Base.invokelatest(checked_import(:PNGFiles).save, stream(s), image, kwargs...)
 end
 
 end # module

--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -2,43 +2,38 @@ module ImageIO
 
 using FileIO: File, DataFormat, Stream, stream
 
+const load_locker = Base.ReentrantLock()
+
+function checked_import(pkg::Symbol)
+    lock(load_locker) do
+        if !isdefined(ImageIO, pkg)
+            @eval ImageIO import $pkg
+        end
+    end
+    return nothing
+end
+
 ## PNGs
-const PNGFiles_LOADED = Ref(false)
 
 function load(f::File{DataFormat{:PNG}}; kwargs...)
-    if !PNGFiles_LOADED[]
-        @eval ImageIO import PNGFiles
-        PNGFiles_LOADED[] = isdefined(ImageIO, :PNGFiles)
-    end
+    checked_import(:PNGFiles)
     return Base.invokelatest(PNGFiles.load, f.filename, kwargs...)
 end
 function load(s::Stream{DataFormat{:PNG}}; kwargs...)
-    if !PNGFiles_LOADED[]
-        @eval ImageIO import PNGFiles
-        PNGFiles_LOADED[] = isdefined(ImageIO, :PNGFiles)
-    end
+    checked_import(:PNGFiles)
     return Base.invokelatest(PNGFiles.load, stream(s), kwargs...)
 end
 function load(s::IO; kwargs...)
-    if !PNGFiles_LOADED[]
-        @eval ImageIO import PNGFiles
-        PNGFiles_LOADED[] = isdefined(ImageIO, :PNGFiles)
-    end
+    checked_import(:PNGFiles)
     return Base.invokelatest(PNGFiles.load, s, kwargs...)
 end
 
 function save(f::File{DataFormat{:PNG}}, image::S; kwargs...) where {T, S<:Union{AbstractMatrix, AbstractArray{T,3}}}
-    if !PNGFiles_LOADED[]
-        @eval ImageIO import PNGFiles
-        PNGFiles_LOADED[] = isdefined(ImageIO, :PNGFiles)
-    end
+    checked_import(:PNGFiles)
     return Base.invokelatest(PNGFiles.save, f.filename, image, kwargs...)
 end
 function save(s::Stream{DataFormat{:PNG}}, image::S; kwargs...) where {T, S<:Union{AbstractMatrix, AbstractArray{T,3}}}
-    if !PNGFiles_LOADED[]
-        @eval ImageIO import PNGFiles
-        PNGFiles_LOADED[] = isdefined(ImageIO, :PNGFiles)
-    end
+    checked_import(:PNGFiles)
     return Base.invokelatest(PNGFiles.save, stream(s), image, kwargs...)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,21 +2,28 @@ using Test
 using ImageIO
 using FileIO: File, DataFormat, Stream, @format_str
 
+tmpdir = mktempdir()
 @testset "ImageIO" begin
 
     @testset "PNGs" begin
+
+        @testset "Threaded save" begin
+            # test that loading of PNGFiles happens sequentially and doesn't segfault
+            img = rand(UInt8, 10, 10)
+            Threads.@threads for i in 1:Threads.nthreads()
+                f = File{DataFormat{:PNG}}(joinpath(tmpdir, "test_fpath_$i.png"))
+                ImageIO.save(f, img)
+            end
+        end
         img = rand(UInt8, 10, 10)
-        f = File{DataFormat{:PNG}}("test_fpath.png")
+        f = File{DataFormat{:PNG}}(joinpath(tmpdir, "test_fpath.png"))
         ImageIO.save(f, img)
         img_saveload = ImageIO.load(f)
         @test all(img .== reinterpret(UInt8, img_saveload))
-        
-        open(io->ImageIO.save(Stream(format"PNG", io), img), "test_io.png", "w")
-        img_saveload = open(io->ImageIO.load(Stream(format"PNG", io)), "test_io.png")
+
+        open(io->ImageIO.save(Stream(format"PNG", io), img), joinpath(tmpdir, "test_io.png"), "w")
+        img_saveload = open(io->ImageIO.load(Stream(format"PNG", io)), joinpath(tmpdir, "test_io.png"))
         @test all(img .== reinterpret(UInt8, img_saveload))
     end
 
 end
-
-rm("test_fpath.png", force=true)
-rm("test_io.png", force=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,16 +3,19 @@ using ImageIO
 using FileIO: File, DataFormat, Stream, @format_str
 
 tmpdir = mktempdir()
+Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), multithread tests will be disabled"
 @testset "ImageIO" begin
 
     @testset "PNGs" begin
 
-        @testset "Threaded save" begin
-            # test that loading of PNGFiles happens sequentially and doesn't segfault
-            img = rand(UInt8, 10, 10)
-            Threads.@threads for i in 1:Threads.nthreads()
-                f = File{DataFormat{:PNG}}(joinpath(tmpdir, "test_fpath_$i.png"))
-                ImageIO.save(f, img)
+        if Threads.nthreads() > 1
+            @testset "Threaded save" begin
+                # test that loading of PNGFiles happens sequentially and doesn't segfault
+                img = rand(UInt8, 10, 10)
+                Threads.@threads for i in 1:Threads.nthreads()
+                    f = File{DataFormat{:PNG}}(joinpath(tmpdir, "test_fpath_$i.png"))
+                    ImageIO.save(f, img)
+                end
             end
         end
         img = rand(UInt8, 10, 10)


### PR DESCRIPTION
Loading via FileIO/ImageIO in threaded loops doesn't appear to be threadsafe https://discourse.julialang.org/t/segfault-while-loading-images-in-multiple-threads/48878/10

This ensures that the checking and loading of PNGFiles is done sequentially, the cost of which is negligible

The execution time of the new `checked_import`
```
0.530126 seconds (893.98 k allocations: 64.787 MiB, 2.17% gc time, 18.76% compilation time)
  0.000001 seconds
  0.000001 seconds
  0.000001 seconds
  0.000001 seconds
  0.000001 seconds
```

The matching PR in FileIO: https://github.com/JuliaIO/FileIO.jl/pull/276