### PR TITLE
Fix bug in load assumptions

### DIFF
--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -6,18 +6,18 @@ const load_locker = Base.ReentrantLock()
 
 function checked_import(pkg::Symbol)
     lock(load_locker) do
-        if isdefined(Main, pkg)
-            m1 = getfield(Main, pkg)
-            isa(m1, Module) && return m1
-        end
         if isdefined(ImageIO, pkg)
             m1 = getfield(ImageIO, pkg)
             isa(m1, Module) && return m1
         end
+        if isdefined(Main, pkg)
+            m1 = getfield(Main, pkg)
+            isa(m1, Module) && return m1
+        end
         m = _findmod(pkg)
         m == nothing || return Base.loaded_modules[m]
-        topimport(pkg)
-        return Base.loaded_modules[_findmod(pkg)]
+        @eval ImageIO import $pkg
+        return Base.getfield(ImageIO, pkg)
     end
 end
 


### PR DESCRIPTION
#11 introduced a bug where it imported PNGFiles at the top level, where PNGFiles may not be available in the Project.

This allows loading from the top level, if available, but falls back to loading into the ImageIO module, where it is available