### PR TITLE
Added Netpbm format handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,12 +10,14 @@ PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 
 [compat]
 FileIO = "1.2"
+ImageCore = "0.8.1"
 Netpbm = "1.0"
 PNGFiles = "0.3"
 julia = "1.3"
 
 [extras]
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "ImageCore"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.3.1"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+Netpbm = "f09324ee-3d7c-5217-9330-fc30815ba969"
 PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 
 [compat]
 FileIO = "1.2"
+Netpbm = "1.0"
 PNGFiles = "0.3"
 julia = "1.3"
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ FileIO.jl integration for image files
 
 Currently provides:
 - PNGFiles.jl for Portable Network Graphics via libpng - ([Benchmark vs. ImageMagick & QuartzImageIO](https://github.com/JuliaIO/PNGFiles.jl/issues/1#issuecomment-586749654))
+- Netpbm.jl for Portable Bitmap formats (in pure Julia)
 
 
 ## Installation
@@ -23,4 +24,6 @@ pkg> add ImageIO  # Press ']' to enter te Pkg REPL mode
 using FileIO
 save("test.png", rand(Gray, 100, 100))
 load("test.png")
+save("test.ppm", rand(RGB, 100, 100))
+load("test.ppm")
 ```

--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -40,4 +40,26 @@ function save(s::Stream{DataFormat{:PNG}}, image::S; kwargs...) where {T, S<:Uni
     return Base.invokelatest(checked_import(:PNGFiles).save, stream(s), image, kwargs...)
 end
 
+# Netpbm types
+
+for NETPBMFORMAT in (:PBMBinary, :PGMBinary, :PPMBinary, :PBMText, :PGMText, :PPMText)
+    @eval begin
+        function load(f::File{DataFormat{$(Expr(:quote,NETPBMFORMAT))}})
+            return Base.invokelatest(checked_import(:Netpbm).load, f)
+        end
+
+        function load(s::Stream{DataFormat{$(Expr(:quote,NETPBMFORMAT))}})
+            return Base.invokelatest(checked_import(:Netpbm).load, s)
+        end
+
+        function save(f::File{DataFormat{$(Expr(:quote,NETPBMFORMAT))}}, image::S; kwargs...) where {S<:AbstractMatrix}
+            return Base.invokelatest(checked_import(:Netpbm).save, f, image; kwargs...)
+        end
+
+        function save(s::Stream{DataFormat{$(Expr(:quote,NETPBMFORMAT))}}, image::S; kwargs...) where {S<:AbstractMatrix}
+            return Base.invokelatest(checked_import(:Netpbm).save, s, image; kwargs...)
+        end
+    end
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using ImageIO
 using FileIO: File, DataFormat, Stream, @format_str
+using ImageCore: N0f8, RGB
 
 tmpdir = mktempdir()
 Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), multithread tests will be disabled"
@@ -29,4 +30,48 @@ Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), mu
         @test all(img .== reinterpret(UInt8, img_saveload))
     end
 
+    @testset "Portable bitmap" begin
+
+        @testset "Bicolor pbm" begin
+            img = rand(0:1, 10, 10)
+            for fmt in (format"PBMBinary", format"PBMText")
+                f = File{fmt}(joinpath(tmpdir, "test_fpath.pbm"))
+                ImageIO.save(f, img)
+                img_saveload = ImageIO.load(f)
+                @test img == img_saveload
+
+                open(io->ImageIO.save(Stream(fmt, io), img), joinpath(tmpdir, "test_io.pbm"), "w")
+                img_saveload = open(io->ImageIO.load(Stream(fmt, io)), joinpath(tmpdir, "test_io.pbm"))
+                @test img == img_saveload
+            end
+        end
+
+        @testset "Gray pgm" begin
+            img = rand(N0f8, 10, 10)
+            for fmt in (format"PGMBinary", format"PGMText")
+                f = File{fmt}(joinpath(tmpdir, "test_fpath.pgm"))
+                ImageIO.save(f, img)
+                img_saveload = ImageIO.load(f)
+                @test img == img_saveload
+
+                open(io->ImageIO.save(Stream(fmt, io), img), joinpath(tmpdir, "test_io.pgm"), "w")
+                img_saveload = open(io->ImageIO.load(Stream(fmt, io)), joinpath(tmpdir, "test_io.pgm"))
+                @test img == img_saveload
+            end
+        end
+
+        @testset "Color ppm" begin
+            img = rand(RGB{N0f8}, 10, 10)
+            for fmt in (format"PPMBinary", format"PPMText")
+                f = File{fmt}(joinpath(tmpdir, "test_fpath.ppm"))
+                ImageIO.save(f, img)
+                img_saveload = ImageIO.load(f)
+                @test img == img_saveload
+
+                open(io->ImageIO.save(Stream(fmt, io), img), joinpath(tmpdir, "test_io.ppm"), "w")
+                img_saveload = open(io->ImageIO.load(Stream(fmt, io)), joinpath(tmpdir, "test_io.ppm"))
+                @test img == img_saveload
+            end
+        end
+    end
 end


### PR DESCRIPTION
In response to the conversation https://github.com/JuliaIO/FileIO.jl/pull/280 this PR adds Netpbm formats to those handled by ImageIO. Includes tests of the new code.