### PR TITLE
Provide FileIO expected function names. Add precompiles

### DIFF
--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -89,4 +89,10 @@ function save(s::Stream{DataFormat{:TIFF}}, image::S; permute_horizontal=false, 
     end
 end
 
+## Precompiles
+
+if Base.VERSION >= v"1.5"
+    @assert Base.precompile(Tuple{typeof(checked_import),Symbol})
+end
+
 end # module

--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -89,8 +89,11 @@ function save(s::Stream{DataFormat{:TIFF}}, image::S; permute_horizontal=false, 
     end
 end
 
-## Precompiles
+## Function names labelled for FileIO. Makes FileIO lookup quicker
+const fileio_save = save
+const fileio_load = load
 
+## Precompiles
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     @assert Base.precompile(Tuple{typeof(checked_import),Symbol})

--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -91,8 +91,13 @@ end
 
 ## Precompiles
 
-if Base.VERSION >= v"1.5"
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     @assert Base.precompile(Tuple{typeof(checked_import),Symbol})
+end
+
+if Base.VERSION >= v"1.5"
+    _precompile_()
 end
 
 end # module


### PR DESCRIPTION
Adds expected function names to avoid the method lookup here 
https://github.com/JuliaIO/FileIO.jl/blob/08e348c2b4d3b5c8969e3f9b23e81af9577500c0/src/loadsave.jl#L235