### PR TITLE
add sixel support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Netpbm = "f09324ee-3d7c-5217-9330-fc30815ba969"
 OpenEXR = "52e1d378-f018-4a11-a4be-720524705ac7"
 PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 QOI = "4b34888f-f399-49d4-9bb3-47ed5cae4e65"
+Sixel = "45858cf5-a6b0-47a3-bbea-62219f50df47"
 TiffImages = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
@@ -20,11 +21,13 @@ OpenEXR = "0.3"
 PNGFiles = "0.3"
 QOI = "1"
 TiffImages = "0.3, 0.4, 0.5"
+Sixel = "0.1.2"
 julia = "1.6"
 
 [extras]
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
+ImageQualityIndexes = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ImageCore"]
+test = ["Test", "ImageCore", "ImageQualityIndexes"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently provides:
 - [TiffImages.jl](https://github.com/tlnagy/TiffImages.jl) for TIFFs (in pure Julia)
 - [OpenEXR.jl](https://github.com/twadleigh/OpenEXR.jl) for OpenEXR files (wrapping the C API provided by the [OpenEXR](https://github.com/AcademySoftwareFoundation/openexr) library)
 - [QOI.jl](https://github.com/KristofferC/QOI.jl) for [QOI](https://qoiformat.org/) files (in pure Julia)
+- [Sixel.jl](https://github.com/johnnychen94/Sixel.jl) for DEC SIXEL graphics (wrapping the C API provided by [libsixel](https://github.com/libsixel/libsixel))
 
 
 ## Installation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using ImageIO
 using FileIO: File, DataFormat, Stream, @format_str
 using ImageCore: N0f8, RGB, Gray, RGBA, GrayA
+using ImageQualityIndexes
 
 tmpdir = mktempdir()
 Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), multithread tests will be disabled"
@@ -146,6 +147,26 @@ Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), mu
             img_saveload = ImageIO.load(f)
             @test img == img_saveload
             @test typeof(img_saveload) == ImageIO.canonical_type(f, img_saveload)
+        end
+    end
+
+    @testset "sixel" begin
+        for typ in [Gray{N0f8}, Gray{Float64}, RGB{N0f8}, RGB{Float64}] # TODO: Add UInt8, N0f8 support in TiffImages
+            @testset "$typ sixel" begin
+                img = repeat(typ.(0:0.1:0.9), inner=(10, 50))
+                f = File{format"SIXEL"}(joinpath(tmpdir, "test_fpath.sixel"))
+                ImageIO.save(f, img)
+                img_saveload = ImageIO.load(f)
+                @test eltype(img_saveload) == RGB{N0f8} # currently Sixel forces eltype to be RGB{N0f8}
+                @test assess_psnr(img, eltype(img).(img_saveload)) > 30 # Sixel encode involves lossy quantization and dither operations
+                @test typeof(img_saveload) == ImageIO.canonical_type(f, img_saveload)
+
+                open(io->ImageIO.save(Stream{format"SIXEL"}(io), img), joinpath(tmpdir, "test_io.sixel"), "w")
+                img_saveload = open(io->ImageIO.load(Stream{format"SIXEL"}(io)), joinpath(tmpdir, "test_io.sixel"))
+                @test eltype(img_saveload) == RGB{N0f8} # currently Sixel forces eltype to be RGB{N0f8}
+                @test assess_psnr(img, eltype(img).(img_saveload)) > 30 # Sixel encode involves lossy quantization and dither operations
+                @test typeof(img_saveload) == ImageIO.canonical_type(f, img_saveload)
+            end
         end
     end
 end


### PR DESCRIPTION
Although the most common usage of it is for terminal visualization, sixel itself is an indexed image format with lossy encoding operations(e.g., quantization, dithering).

Since it's an indexed image, not converting `IndrectArray` to dense `Array` is memory efficient. For this purpose, I introduce a new dependency `IndirectArrays`.

- [x] blocked by https://github.com/JuliaRegistries/General/pull/36526