### PR TITLE
ImageIO v0.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageIO"
 uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
 authors = ["Ian Butterworth"]
-version = "0.5.9"
+version = "0.6.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FileIO.jl integration for image files
 
-![Julia version](https://img.shields.io/badge/julia-%3E%3D%201.3-blue)
+![Julia version](https://img.shields.io/badge/julia-%3E%3D%201.6-blue)
 [![Run tests](https://github.com/JuliaIO/ImageIO.jl/actions/workflows/test.yml/badge.svg)](https://github.com/JuliaIO/ImageIO.jl/actions/workflows/test.yml)
 [![Codecov](https://codecov.io/gh/JuliaIO/ImageIO.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaIO/ImageIO.jl)
 
@@ -38,7 +38,7 @@ load("test.tiff")
 
 ## Compatibility
 
-This package requires Julia at least v1.3. For old Julia versions, a dummy ImageIO version v0.0.1 with no real function will be installed.
+If you're using old Julia versions (`VERSION < v"1.3"`), a dummy ImageIO version v0.0.1 with no real function will be installed.
 In this case, you still need to install [ImageMagick.jl] to make `FileIO.save`/`FileIO.load` work.
 
 [ImageMagick.jl]: https://github.com/JuliaIO/ImageMagick.jl

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ FileIO.jl integration for image files
 [![Run tests](https://github.com/JuliaIO/ImageIO.jl/actions/workflows/test.yml/badge.svg)](https://github.com/JuliaIO/ImageIO.jl/actions/workflows/test.yml)
 [![Codecov](https://codecov.io/gh/JuliaIO/ImageIO.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaIO/ImageIO.jl)
 
-Currently provides:
-- [PNGFiles.jl](https://github.com/JuliaIO/PNGFiles.jl) for Portable Network Graphics via libpng - ([Benchmark vs. ImageMagick & QuartzImageIO](https://github.com/JuliaIO/PNGFiles.jl/issues/1#issuecomment-586749654))
-- [Netpbm.jl](https://github.com/JuliaIO/Netpbm.jl) for Portable Bitmap formats (in pure Julia)
-- [TiffImages.jl](https://github.com/tlnagy/TiffImages.jl) for TIFFs (in pure Julia)
-- [OpenEXR.jl](https://github.com/twadleigh/OpenEXR.jl) for OpenEXR files (wrapping the C API provided by the [OpenEXR](https://github.com/AcademySoftwareFoundation/openexr) library)
-- [QOI.jl](https://github.com/KristofferC/QOI.jl) for [QOI](https://qoiformat.org/) files (in pure Julia)
-- [Sixel.jl](https://github.com/johnnychen94/Sixel.jl) for DEC SIXEL graphics (wrapping the C API provided by [libsixel](https://github.com/libsixel/libsixel))
+| Format | Extensions | Provider | Implementation | Comment |
+| ------- | ---------- | -------- | ---- | ----------- |
+| [OpenEXR](https://www.openexr.com/) | `.exr` | [OpenEXR.jl](https://github.com/twadleigh/OpenEXR.jl) | Julia wrapper of [OpenEXR](https://github.com/AcademySoftwareFoundation/openexr) | |
+| Portable Bitmap formats | `.pbm`, `.pgm`, `.ppm` | [Netpbm.jl](https://github.com/JuliaIO/Netpbm.jl) | pure Julia | |
+| PNG (Portable Network Graphics) | `.png` | [PNGFiles.jl](https://github.com/JuliaIO/PNGFiles.jl) | Julia wrapper of [libpng](https://github.com/glennrp/libpng) | [Benchmark vs. ImageMagick & QuartzImageIO](https://github.com/JuliaIO/PNGFiles.jl/issues/1#issuecomment-586749654) |
+| [QOI (Quite Okay Image)](https://qoiformat.org/) format | `.qoi` | [QOI.jl](https://github.com/KristofferC/QOI.jl) | pure Julia | |
+| DEC SIXEL (six-pixels) graphics | `.six`, `.sixel` | [Sixel.jl](https://github.com/johnnychen94/Sixel.jl) | Julia wrapper of [libsixel](https://github.com/libsixel/libsixel) | |
+| TIFF (Tag Image File Format) | `.tiff`, `.tif` | [TiffImages.jl](https://github.com/tlnagy/TiffImages.jl) | pure Julia | check [OMETIFF.jl](https://github.com/tlnagy/OMETIFF.jl) for OMETIFF support |
 
 
 ## Installation


### PR DESCRIPTION
Changes in v0.6.0:

- new format QOI(#42)
- new format SIXEL(#31)
- bump Julia lower bound from 1.3 to 1.6. This is required by both QOI and SIXEL.