### PR TITLE
CI: adds back test for Julia 1.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1', 'nightly']
+        julia-version: ['1.6', '1', 'nightly']
         julia-arch: [x64]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         include:


### PR DESCRIPTION
This partially reverts the CI change in #42, the idea is to still ensure we're working well on the lower bound Julia version. I'll merge once the test passes.