### PR TITLE
add IndirectArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.6.1"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 JpegTurbo = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
 Netpbm = "f09324ee-3d7c-5217-9330-fc30815ba969"
 OpenEXR = "52e1d378-f018-4a11-a4be-720524705ac7"
@@ -16,8 +17,9 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 FileIO = "1.2"
-JpegTurbo = "0.1"
+IndirectArrays = "0.5, 1"
 ImageCore = "0.8.1, 0.9"
+JpegTurbo = "0.1"
 Netpbm = "1.0"
 OpenEXR = "0.3"
 PNGFiles = "0.3"

--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -3,6 +3,8 @@ module ImageIO
 using UUIDs
 using FileIO: File, DataFormat, Stream, stream, Formatted
 
+import IndirectArrays: IndirectArray
+
 const idSixel = Base.PkgId(UUID("45858cf5-a6b0-47a3-bbea-62219f50df47"), "Sixel")
 const idNetpbm = Base.PkgId(UUID("f09324ee-3d7c-5217-9330-fc30815ba969"), "Netpbm")
 const idPNGFiles = Base.PkgId(UUID("f57f5aa1-a3ce-4bc8-8ab9-96f992907883"), "PNGFiles")
@@ -17,7 +19,6 @@ const idJpegTurbo = Base.PkgId(UUID("b835a17e-a41a-41e7-81f0-2f016b05efe0"), "Jp
 for FMT in (
     :PBMBinary, :PGMBinary, :PPMBinary, :PBMText, :PGMText, :PPMText,
     :TIFF,
-    :PNG,
     :EXR,
     :QOI,
     :SIXEL,
@@ -26,6 +27,7 @@ for FMT in (
     @eval canonical_type(::DataFormat{$(Expr(:quote, FMT))}, ::AbstractArray{T, N}) where {T,N} =
         Array{T,N}
 end
+@inline canonical_type(::DataFormat{:PNG}, ::AbstractArray{T, N}) where {T,N} = Union{Array{T,N}, IndirectArray{T,N}}
 @inline canonical_type(::Formatted{T}, data) where T = canonical_type(T(), data)
 
 function enforce_canonical_type(f, data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using ImageIO
 using FileIO: File, DataFormat, Stream, @format_str
 using ImageCore: N0f8, RGB, Gray, RGBA, GrayA, n0f8
+using IndirectArrays
 using ImageQualityIndexes
 
 tmpdir = mktempdir()
@@ -30,7 +31,7 @@ Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), mu
                 else
                     @test img == img_saveload
                 end
-                @test typeof(img_saveload) == ImageIO.canonical_type(f, img_saveload)
+                @test img_saveload isa Array
                 img_saveload = ImageIO.load(f; gamma=1.0)
                 if typ == UInt8
                     @test all(img .== reinterpret(UInt8, img_saveload))
@@ -45,7 +46,7 @@ Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), mu
                 else
                     @test img == img_saveload
                 end
-                @test typeof(img_saveload) == ImageIO.canonical_type(f, img_saveload)
+                @test img_saveload isa Array
 
                 ImageIO.save(f, img; compression_level=1)
                 img_saveload = ImageIO.load(f)
@@ -55,6 +56,16 @@ Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), mu
                     @test img == img_saveload
                 end
             end
+        end
+
+        @testset "indexed image" begin
+            f = File{DataFormat{:PNG}}(joinpath(tmpdir, "test_fpath.png"))
+            img = IndirectArray(rand(1:5, 4, 4), rand(RGB{N0f8}, 5))
+            ImageIO.save(f, img)
+            img_saveload = ImageIO.load(f)
+
+            @test img == img_saveload
+            @test img isa IndirectArray
         end
     end
 


### PR DESCRIPTION
This adds IndirectArrays as an ImageIO dependency to support indexed image format. Because IndirectArrays is a very light package, it adds merely no latency to ImageIO.

For other image types, e.g., pyramidal image supported by TiffImages. We could do the same thing here, i.e., separating the array definition into a light package similar to IndirectArrays.jl and adding it here. (cc: @tlnagy)

This way we can introduce it to ImageIO and also ImageCore. See also the recent note on JuliaImages's philosophy https://github.com/JuliaImages/ImageCore.jl/issues/180; I'm considering supporting various image layout formats in ImageCore.

Closes #47