### PR TITLE
Adds GIF format to ImageIO

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.6.6"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+GIFImages = "7064036c-d33e-4a25-b247-cf6150d8ad81"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 JpegTurbo = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
 LazyModules = "8cdb02fc-e678-4876-92c5-9defec4f444e"
@@ -18,6 +19,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 FileIO = "1.2"
+GIFImages = "0.1"
 ImageCore = "0.8.1, 0.9"
 IndirectArrays = "0.5, 1"
 JpegTurbo = "0.1"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ FileIO.jl integration for image files
 
 | Format | Extensions | Provider | Implementation | Comment |
 | ------- | ---------- | -------- | ---- | ----------- |
+| GIF | `.gif` | [GIFImages.jl](https://github.com/JuliaIO/GIFImages.jl) | Julia wrapper of [giflib](https://sourceforge.net/projects/giflib/) | |
 | JPEG | `.jpg`, `.jpeg` | [JpegTurbo.jl](https://github.com/johnnychen94/JpegTurbo.jl) | Julia wrapper of [libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo) | [Benchmark results against other backends](https://github.com/johnnychen94/JpegTurbo.jl/issues/15) |
 | [OpenEXR](https://www.openexr.com/) | `.exr` | [OpenEXR.jl](https://github.com/twadleigh/OpenEXR.jl) | Julia wrapper of [OpenEXR](https://github.com/AcademySoftwareFoundation/openexr) | |
 | Portable Bitmap formats | `.pbm`, `.pgm`, `.ppm` | [Netpbm.jl](https://github.com/JuliaIO/Netpbm.jl) | pure Julia | |

--- a/src/ImageIO.jl
+++ b/src/ImageIO.jl
@@ -14,6 +14,7 @@ using LazyModules # @lazy macro is used to delay the package loading to its firs
 @lazy import OpenEXR = "52e1d378-f018-4a11-a4be-720524705ac7"
 @lazy import QOI = "4b34888f-f399-49d4-9bb3-47ed5cae4e65"
 @lazy import JpegTurbo = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
+@lazy import GIFImages = "7064036c-d33e-4a25-b247-cf6150d8ad81"
 
 # Enforce a type conversion to be backend independent (issue #25)
 # Note: If the backend does not provide efficient `convert` implementation,
@@ -24,7 +25,8 @@ for FMT in (
     :EXR,
     :QOI,
     :SIXEL,
-    :JPEG
+    :JPEG,
+    :GIF
 )
     @eval canonical_type(::DataFormat{$(Expr(:quote, FMT))}, ::AbstractArray{T, N}) where {T,N} =
         Array{T,N}
@@ -184,6 +186,19 @@ function save(f::File{DataFormat{:JPEG}}, image::AbstractArray; kwargs...)
 end
 function save(s::Stream{DataFormat{:JPEG}}, image::AbstractArray; kwargs...)
     JpegTurbo.fileio_save(s, image; kwargs...)
+end
+
+# GIF
+function load(f::File{DataFormat{:GIF}}; kwargs...)
+    data = GIFImages.fileio_load(f, kwargs...)
+    return enforce_canonical_type(f, data)
+end
+function load(s::Stream{DataFormat{:GIF}}; kwargs...)
+    data = GIFImages.fileio_load(s, kwargs...)
+    return enforce_canonical_type(s, data)
+end
+function save(f::File{DataFormat{:GIF}}, image::AbstractArray; kwargs...)
+    GIFImages.fileio_save(f, image; kwargs...)
 end
 
 ## Function names labelled for FileIO. Makes FileIO lookup quicker

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -210,4 +210,18 @@ Threads.nthreads() <= 1 && @info "Threads.nthreads() = $(Threads.nthreads()), mu
             end
         end
     end
+
+    @testset "GIF" begin
+        for typ in [Gray{N0f8}, Gray{Float64}, RGB{N0f8}, RGB{Float64}]
+            @testset "$typ GIF" begin
+                img = repeat(typ.(0:0.1:0.9), inner=(10, 50))
+                f = File{format"GIF"}(joinpath(tmpdir, "test_fpath.gif"))
+                ImageIO.save(f, img)
+                img_saveload = ImageIO.load(f)
+                @test eltype(img_saveload) == n0f8(typ)
+                @test assess_psnr(img, eltype(img).(img_saveload)) > 51
+                @test typeof(img_saveload) == ImageIO.canonical_type(f, img_saveload)
+            end
+        end
+    end
 end


### PR DESCRIPTION
WIP, GIFImages has load with io and file method and save with just file approach. Test error out right now but I am not able to understand why as fileio_save with filepath is available.
- [ ] Add GIF format to ImageIO