### PR TITLE
CI: Expanded testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,19 +23,37 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
           - '1'
-          - 'nightly'
+          - lts
+          - '1.6'
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macOS-latest # aarch64 runner
+          - macOS-13 # x64 runner
           - windows-latest
         arch:
           - x64
+          - aarch64
           - x86
         exclude:
+          - os: macOS-13
+            arch: aarch64
+          - os: macOS-latest
+            arch: x64
+          - os: macOS-latest
+            version: '1.6'
           - os: macOS-latest
             arch: x86
+          - os: macOS-13
+            arch: x86
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
+        include:
+          - os: ubuntu-latest
+            arch: x64
+            version: nightly
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v2
       with:
-        version: '1'
+        version: '1.10'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@latest
     - uses: julia-actions/julia-invalidations@v1


### PR DESCRIPTION
Expanded testing to include both current, and previous LTS versions, in addition to the current stable version - on all tier 1 CPU archs.

Fixed testing on macOS wrt. to new definition of macOS-latest (being an aarch64 runner): https://discourse.julialang.org/t/how-to-fix-github-actions-ci-failures-with-julia-1-6-or-1-7-on-macos-latest-and-macos-14/117019

Reduced testing on nightly to ubuntu on x64.

Also, fixed Invalidations workflow by using Julia 1.10.